### PR TITLE
[Feat] 검색 기능 구현

### DIFF
--- a/src/apis/base-api.ts
+++ b/src/apis/base-api.ts
@@ -1,6 +1,9 @@
 import { baseInstance } from './instance.ts';
 import { z } from 'zod';
-import { ReadRecruitmentByCodeResponseSchema } from './response-body-schema.ts';
+import {
+  ReadRecruitmentByCodeResponseSchema,
+  ReadRecruitmentSearchResponseSchema,
+} from './response-body-schema.ts';
 import { convertSeoulToUTC } from '../lib/utils/convert.ts';
 
 /*
@@ -20,4 +23,12 @@ export async function readRecruitmentByCode(
   }
 
   return response.data;
+}
+
+export async function readRecruitmentSearch(prefix: string, limit: number) {
+  const response = await baseInstance.get(
+    `recruitments/search?prefix=${prefix}&limit=${limit}`,
+  );
+
+  return ReadRecruitmentSearchResponseSchema.parse(response.data);
 }

--- a/src/apis/base-api.ts
+++ b/src/apis/base-api.ts
@@ -25,7 +25,10 @@ export async function readRecruitmentByCode(
   return response.data;
 }
 
-export async function readRecruitmentSearch(prefix: string, limit: number) {
+export async function readRecruitmentSearch(
+  prefix: string,
+  limit: number,
+): Promise<z.infer<typeof ReadRecruitmentSearchResponseSchema>> {
   const response = await baseInstance.get(
     `recruitments/search?prefix=${prefix}&limit=${limit}`,
   );

--- a/src/apis/response-body-schema.ts
+++ b/src/apis/response-body-schema.ts
@@ -61,6 +61,4 @@ export const SaveApplicationResponseSchema = ApplicationDetailSchema;
 
 export const ReadRecruitmentByCodeResponseSchema = RecruitmentSchema;
 
-export const ReadRecruitmentSearchResponseSchema = z.array(
-  RecruitmentSearchSchema,
-);
+export const ReadRecruitmentSearchResponseSchema = RecruitmentSearchSchema;

--- a/src/apis/response-body-schema.ts
+++ b/src/apis/response-body-schema.ts
@@ -3,6 +3,7 @@ import { ProgressSchema } from '../lib/types/schemas/progress-schema.ts';
 import {
   CreatedRecruitmentSchema,
   RecruitmentSchema,
+  RecruitmentSearchSchema,
 } from '../lib/types/schemas/recruitment-schema.ts';
 import {
   ApplicationDetailSchema,
@@ -59,3 +60,7 @@ export const ReadApplicationResponseSchema =
 export const SaveApplicationResponseSchema = ApplicationDetailSchema;
 
 export const ReadRecruitmentByCodeResponseSchema = RecruitmentSchema;
+
+export const ReadRecruitmentSearchResponseSchema = z.array(
+  RecruitmentSearchSchema,
+);

--- a/src/apis/response-body-schema.ts
+++ b/src/apis/response-body-schema.ts
@@ -3,7 +3,7 @@ import { ProgressSchema } from '../lib/types/schemas/progress-schema.ts';
 import {
   CreatedRecruitmentSchema,
   RecruitmentSchema,
-  RecruitmentSearchSchema,
+  RecruitmentSearchResultSchema,
 } from '../lib/types/schemas/recruitment-schema.ts';
 import {
   ApplicationDetailSchema,
@@ -61,4 +61,6 @@ export const SaveApplicationResponseSchema = ApplicationDetailSchema;
 
 export const ReadRecruitmentByCodeResponseSchema = RecruitmentSchema;
 
-export const ReadRecruitmentSearchResponseSchema = RecruitmentSearchSchema;
+export const ReadRecruitmentSearchResponseSchema = z.array(
+  RecruitmentSearchResultSchema,
+);

--- a/src/app/lookup-recruitment-form.tsx
+++ b/src/app/lookup-recruitment-form.tsx
@@ -1,9 +1,25 @@
 import { Form } from 'react-router-dom';
-import Input from '../components/shared/input.tsx';
 import { useForm } from 'react-hook-form';
+import { readRecruitmentSearch } from '../apis/base-api.ts';
+import { keepPreviousData, useQuery } from '@tanstack/react-query';
+
+import { z } from 'zod';
+import { RecruitmentSearchResultSchema } from '../lib/types/schemas/recruitment-schema.ts';
+import Autocomplete, {
+  AutocompleteOption,
+} from '../components/shared/autocomplete.tsx';
+import useDebounce from '../hooks/use-debounce.ts';
+
+const READ_RECRUITMENT_SEARCH_QUERY_KEY = 'readRecruitmentSearch';
+
+const LOOKUP_RECRUITMENT_LIMIT = 15;
+
+type RecruitmentSearchResult = z.infer<typeof RecruitmentSearchResultSchema>;
+
+const DEBOUNCE_DELAY = 150;
 
 const LookupRecruitmentForm = () => {
-  const { register, resetField } = useForm<{
+  const { watch, register, resetField } = useForm<{
     searchCrew: string;
   }>({
     defaultValues: {
@@ -11,99 +27,49 @@ const LookupRecruitmentForm = () => {
     },
   });
 
+  const prefix = watch('searchCrew');
+
+  const debouncedPrefix = useDebounce(prefix, DEBOUNCE_DELAY);
+
+  const isEmpty = !debouncedPrefix.trim();
+
+  const { data } = useQuery({
+    queryKey: [READ_RECRUITMENT_SEARCH_QUERY_KEY, debouncedPrefix],
+    queryFn: () =>
+      readRecruitmentSearch(debouncedPrefix, LOOKUP_RECRUITMENT_LIMIT),
+    enabled: !isEmpty,
+    placeholderData: keepPreviousData,
+  });
+
+  const handleSelect = (option: AutocompleteOption) => {
+    //TODO: Implement navigation to recruitment page
+    console.log(option);
+    resetField('searchCrew');
+  };
+
+  const getOptions = (data: RecruitmentSearchResult[] | undefined) => {
+    if (!data) return [];
+
+    return data.map((recruitment) => ({
+      label: recruitment.title,
+      value: recruitment.title,
+    }));
+  };
+
+  // 입력을 한번에 지우면, enable 조건으로 인해 쿼리를 하지 않고, keepPreviousData로 이전 데이터를 유지하는 이슈로 필터링 추가
+  const options = !isEmpty ? getOptions(data) : [];
+
   return (
     <Form action="/recruitment">
-      <Input
-        name="q"
-        className="mb-20 mt-12 py-2"
-        placeholder="동아리명"
+      <Autocomplete
+        options={options}
         registerReturns={register('searchCrew')}
-        clearInput={() => resetField('searchCrew')}
+        onSelect={handleSelect}
+        onClearInput={() => resetField('searchCrew')}
+        isEmpty={isEmpty}
       />
     </Form>
   );
 };
 
 export default LookupRecruitmentForm;
-
-//
-// import React, { useEffect, useState } from 'react';
-// import Input, { InputState } from '../../../components/shared/input.tsx';
-// import { Button } from '../../../components/shadcn/button.tsx';
-// import { SubmitHandler, useForm } from 'react-hook-form';
-// import { useToast } from '../../../hooks/use-toast.ts';
-// import { useNavigate } from 'react-router-dom';
-// import { validateRecruitmentCode } from '../../../lib/utils/regex.ts';
-//
-// type LookUpRecruitmentInput = {
-//   recruitmentCode: string;
-// };
-//
-// const LookupRecruitmentForm = () => {
-//   const { toast } = useToast();
-//   const [error, setError] = useState<boolean>(false);
-//
-//   const { register, resetField, handleSubmit, setFocus, formState } =
-//     useForm<LookUpRecruitmentInput>({
-//       defaultValues: {
-//         recruitmentCode: '',
-//       },
-//     });
-//
-//   const navigate = useNavigate();
-//   const onSubmit: SubmitHandler<LookUpRecruitmentInput> = ({
-//                                                              recruitmentCode,
-//                                                            }) => {
-//     const toastMsg: string = validateRecruitmentCode(recruitmentCode);
-//     if (toastMsg) {
-//       toast({
-//         title: toastMsg,
-//         state: 'error',
-//       });
-//       setError(true);
-//       return;
-//     }
-//     navigate(`/recruitment/${recruitmentCode}`);
-//   };
-//
-//   useEffect(() => {
-//     setFocus('recruitmentCode');
-//   }, [setFocus]);
-//
-//   const inputState: InputState = error
-//     ? 'error'
-//     : formState.dirtyFields.recruitmentCode
-//       ? 'filled'
-//       : 'empty';
-//
-//   return (
-//     <form onSubmit={handleSubmit(onSubmit)}>
-//       <fieldset className="mb-3">
-//         <LocalLegend>지원하기</LocalLegend>
-//         <Input
-//           maxLength={36}
-//           state={inputState}
-//           registerReturns={register('recruitmentCode', {
-//             onChange: () => {
-//               setError(false);
-//             },
-//           })}
-//           clearInput={() => {
-//             resetField('recruitmentCode');
-//             setError(false);
-//           }}
-//           placeholder="모집공고 코드"
-//         />
-//       </fieldset>
-//       <Button className="w-full" disabled={error}>
-//         지원하기
-//       </Button>
-//     </form>
-//   );
-// };
-//
-// export const LocalLegend = ({ children }: { children: React.ReactNode }) => {
-//   return <legend className="mb-3 text-sm font-semibold">{children}</legend>;
-// };
-//
-// export default LookupRecruitmentForm;

--- a/src/components/shared/autocomplete.tsx
+++ b/src/components/shared/autocomplete.tsx
@@ -1,0 +1,126 @@
+import React, { useState } from 'react';
+import { UseFormRegisterReturn } from 'react-hook-form';
+import Input from './input';
+import { cn } from '../../lib/utils/utils';
+
+/**
+ * Autocomplete component options
+ * Properties:
+ * - `label`: The visible text shown to users in the Autocomplete dropdown list.
+ *            This text is used for display purposes only.
+ * - `value`: The underlying data or identifier for the option. This value is typically
+ *            used for form submission or data retrieval based on the user's selection.
+ */
+
+export interface AutocompleteOption {
+  label: string;
+  value: string;
+}
+
+/**
+ * Autocomplete component properties
+ * - `options`: Array of options to display in the dropdown.
+ * - `registerReturns`: Value from `useForm`'s `register` function to connect the input
+ *                      field with the parent form. See: https://react-hook-form.com/api/useform/register
+ * - `onSelect`: Callback when an option is selected, receiving the selected option.
+ * - `onClearInput`: Callback when the input is cleared, typically resetting the field.
+ * - `isEmpty`: Boolean indicating if the input is empty, used to toggle the dropdown.
+ */
+
+interface AutocompleteProps {
+  options: AutocompleteOption[];
+  registerReturns: UseFormRegisterReturn;
+  onSelect: (option: AutocompleteOption) => void;
+  onClearInput: () => void;
+  isEmpty?: boolean;
+}
+
+const Autocomplete = ({
+  options,
+  registerReturns,
+  onSelect,
+  onClearInput,
+  isEmpty = false,
+}: AutocompleteProps) => {
+  const [highlightedIndex, setHighlightedIndex] = useState(-1);
+  const [showOptions, setShowOptions] = useState(true);
+
+  const handleItemClick = (option: AutocompleteOption) => {
+    onSelect(option);
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'ArrowDown') {
+      setHighlightedIndex((prevIndex) => (prevIndex + 1) % options.length);
+    } else if (e.key === 'ArrowUp') {
+      setHighlightedIndex((prevIndex) =>
+        prevIndex <= 0 ? options.length - 1 : prevIndex - 1,
+      );
+    } else if (e.key === 'Enter' && highlightedIndex >= 0) {
+      e.preventDefault();
+      onSelect(options[highlightedIndex]);
+    } else if (e.key === 'Escape') {
+      setShowOptions(false);
+    }
+  };
+
+  const handleBlur: React.FocusEventHandler<HTMLInputElement> = (e) => {
+    e.stopPropagation();
+    setShowOptions(false);
+  };
+
+  const handleFocus: React.FocusEventHandler<HTMLInputElement> = (e) => {
+    e.stopPropagation();
+    setShowOptions(true);
+  };
+
+  return (
+    <div className="relative">
+      <Input
+        className="mb-20 mt-12 py-2"
+        placeholder="동아리명"
+        registerReturns={registerReturns}
+        clearInput={onClearInput}
+        onKeyDown={handleKeyDown}
+        onBlurCapture={handleBlur}
+        onFocusCapture={handleFocus}
+      />
+      <ul
+        className={cn(
+          'absolute left-0 top-full z-10 m-0 w-full list-none rounded border border-crews-g03 bg-white p-2',
+          // 입력이 없거나, blur 혹은 esc가 눌린 경우 display none
+          isEmpty || !showOptions ? 'hidden' : 'block',
+        )}
+      >
+        {options.length !== 0 ? (
+          options.map((item, index) => (
+            <li
+              className={`cursor-pointer rounded`}
+              key={index}
+              onClick={() => handleItemClick(item)}
+              onMouseEnter={() => setHighlightedIndex(index)}
+              onMouseLeave={() => setHighlightedIndex(-1)}
+            >
+              <div
+                className={cn(
+                  'flex items-center rounded px-2 py-2 text-sm font-normal text-crews-bk01',
+                  highlightedIndex === index ? 'bg-crews-b02' : '',
+                )}
+              >
+                {item.label}
+              </div>
+            </li>
+          ))
+        ) : (
+          <li className={`rounded`}>
+            <div className="flex items-center rounded px-2 py-2 text-sm font-normal text-crews-g06">
+              검색 결과가 없습니다.
+            </div>
+          </li>
+        )}
+      </ul>
+    </div>
+  );
+};
+
+export default Autocomplete;

--- a/src/components/shared/autocomplete.tsx
+++ b/src/components/shared/autocomplete.tsx
@@ -64,13 +64,11 @@ const Autocomplete = ({
     }
   };
 
-  const handleBlur: React.FocusEventHandler<HTMLInputElement> = (e) => {
-    e.stopPropagation();
+  const handleBlur = () => {
     setShowOptions(false);
   };
 
-  const handleFocus: React.FocusEventHandler<HTMLInputElement> = (e) => {
-    e.stopPropagation();
+  const handleFocus = () => {
     setShowOptions(true);
   };
 

--- a/src/hooks/use-debounce.ts
+++ b/src/hooks/use-debounce.ts
@@ -1,0 +1,19 @@
+import { useState, useEffect } from 'react';
+
+function useDebounce<T>(value: T, delay: number): T {
+  const [debouncedValue, setDebouncedValue] = useState<T>(value);
+
+  useEffect(() => {
+    const handler = setTimeout(() => {
+      setDebouncedValue(value);
+    }, delay);
+
+    return () => {
+      clearTimeout(handler);
+    };
+  }, [value, delay]);
+
+  return debouncedValue;
+}
+
+export default useDebounce;

--- a/src/lib/types/schemas/recruitment-schema.ts
+++ b/src/lib/types/schemas/recruitment-schema.ts
@@ -31,3 +31,9 @@ export const DateAndTimeSchema = CreatedRecruitmentSchema.pick({
   deadlineDate: true,
   deadlineTime: true,
 });
+
+export const RecruitmentSearchSchema = z.array(
+  z.object({
+    title: z.string(),
+  }),
+);

--- a/src/lib/types/schemas/recruitment-schema.ts
+++ b/src/lib/types/schemas/recruitment-schema.ts
@@ -32,8 +32,6 @@ export const DateAndTimeSchema = CreatedRecruitmentSchema.pick({
   deadlineTime: true,
 });
 
-export const RecruitmentSearchSchema = z.array(
-  z.object({
-    title: z.string(),
-  }),
-);
+export const RecruitmentSearchResultSchema = z.object({
+  title: z.string(),
+});


### PR DESCRIPTION
### 🤔 Description
* 검색 기능 구현하였습니다

### 👋 Related issues
* **Close** #54 

### 🔍 Details

* `readRecruitmentSearch`
  search get api 추가하고, schema, type도 업데이트하였습니다.

* `Autocomplete` 
 `shadcn`에 `Command` 컴포넌트를 사용하려다가, 서비스에 맞게 커스텀하려면 코드가 지저분해져서, 최대한 공통 컴포넌트처럼 사용할 수 있도록 구현하였는데, 리뷰 부탁드립니다!
 
 ```ts
 // option interface고, ui에 보여지는 label, 해당 label이 가지는 실제 value를 가집니다.
 export interface AutocompleteOption {
  label: string;
  value: string;
}

interface AutocompleteProps {
  options: AutocompleteOption[]; // options 배열
  registerReturns: UseFormRegisterReturn; // 훅폼 register을 무조건 사용하도록 강제했습니다
  onSelect: (option: AutocompleteOption) => void; // select 시의 로직
  onClearInput: () => void; // input clear
  isEmpty?: boolean; // 입력 필드가 비었는지 여부, 입력이 있는데 결과가 없는 경우와 분리하기 위해 선언
}
 ```

* `useDebouce`
 사용성을 위해 디바운스 훅 추가하였습니다.
 `react-use` 라이브러리 추가할까하다가 안 쓰는 기능이 많을 것 같아 일단 추가하였는데, 한 번 확인 부탁드립니다!
 [react-use](https://github.com/streamich/react-use)

### 🐛 Bugs
* X

### 💬 Others
* 주석에 추가해두긴 했는데, useQuery의 `keepPreviousData`와 `enable: !!input.trim()` 을 같이 사용하다보니, 입력 도중 모든 입력을 지우면 `enable`로 인해 쿼리를 하지 않고, `keepPreviousData`으로 인해 이전 state가 남아 있는 이슈가 있어서 한번 필터링을 했는데, 더 좋은 의견 있으면 부탁드립니다! 🫡
